### PR TITLE
feat(backend): add Redis caching for drama and video APIs

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -46,6 +46,10 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.session</groupId>
             <artifactId>spring-session-data-redis</artifactId>
         </dependency>

--- a/backend/src/main/java/com/hyx/shortdrama/MainApplication.java
+++ b/backend/src/main/java/com/hyx/shortdrama/MainApplication.java
@@ -4,6 +4,7 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -11,9 +12,11 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  * 主类（项目启动入口）
  */
 // todo 如需开启 Redis，须移除 exclude 中的内容
-@SpringBootApplication(exclude = {RedisAutoConfiguration.class})
+//@SpringBootApplication(exclude = {RedisAutoConfiguration.class})
+@SpringBootApplication
 @MapperScan("com.hyx.shortdrama.mapper")
 @EnableScheduling
+@EnableCaching
 @EnableAspectJAutoProxy(proxyTargetClass = true, exposeProxy = true)
 public class MainApplication {
 

--- a/backend/src/main/java/com/hyx/shortdrama/config/CacheConfig.java
+++ b/backend/src/main/java/com/hyx/shortdrama/config/CacheConfig.java
@@ -1,0 +1,59 @@
+package com.hyx.shortdrama.config;
+
+import com.hyx.shortdrama.constant.CacheConstant;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableConfigurationProperties(CacheTtlProperties.class)
+public class CacheConfig {
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory cf, CacheTtlProperties ttlProps) {
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer();
+
+        RedisCacheConfiguration defaultCfg = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+                .disableCachingNullValues()
+                .prefixCacheNameWith(CacheConstant.PREFIX);
+
+        Map<String, RedisCacheConfiguration> map = new HashMap<>();
+        map.put(CacheConstant.DRAMA_LIST,     defaultCfg.entryTtl(ttlProps.getDramaList()));
+        map.put(CacheConstant.DRAMA_DETAIL,   defaultCfg.entryTtl(ttlProps.getDramaDetail()));
+        map.put(CacheConstant.VIDEO_EPISODES, defaultCfg.entryTtl(ttlProps.getVideoEpisodes()));
+        map.put(CacheConstant.VIDEO_FEED,     defaultCfg.entryTtl(ttlProps.getVideoFeed()));
+        map.put(CacheConstant.DRAMA_SEARCH,   defaultCfg.entryTtl(ttlProps.getDramaSearch()));
+
+        return new RedisCacheManager(
+                RedisCacheWriter.nonLockingRedisCacheWriter(cf),
+                defaultCfg, map
+        );
+    }
+
+    // 全局开关（@Cacheable condition 使用）
+    @Bean
+    public CacheSwitch cacheSwitch(@Value("${shortdrama.cache.enabled:true}") boolean enabled){
+        return new CacheSwitch(enabled);
+    }
+
+    public static class CacheSwitch {
+        private  final boolean enabled;
+        public CacheSwitch(boolean enabled) {
+            this.enabled = enabled;
+        }
+        public boolean isEnabled() {
+            return enabled;
+        }
+    }
+}

--- a/backend/src/main/java/com/hyx/shortdrama/config/CacheTtlProperties.java
+++ b/backend/src/main/java/com/hyx/shortdrama/config/CacheTtlProperties.java
@@ -1,0 +1,16 @@
+package com.hyx.shortdrama.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+@Data
+@ConfigurationProperties(prefix = "shortdrama.cache.ttl")
+public class CacheTtlProperties {
+    private Duration dramaList = Duration.ofMinutes(5);
+    private Duration dramaDetail = Duration.ofMinutes(30);
+    private Duration videoEpisodes = Duration.ofMinutes(30);
+    private Duration videoFeed = Duration.ofSeconds(30);
+    private Duration dramaSearch = Duration.ofSeconds(30);
+}

--- a/backend/src/main/java/com/hyx/shortdrama/constant/CacheConstant.java
+++ b/backend/src/main/java/com/hyx/shortdrama/constant/CacheConstant.java
@@ -1,0 +1,14 @@
+package com.hyx.shortdrama.constant;
+
+public final class CacheConstant {
+    public static final String PREFIX = "sd:";
+
+    // cacheNames
+    public static final String DRAMA_LIST = "drama:list";
+    public static final String DRAMA_DETAIL = "drama:detail";
+    public static final String VIDEO_EPISODES = "video:episodes";
+    public static final String VIDEO_FEED = "video:feed";
+    public static final String DRAMA_SEARCH = "drama:search";
+
+    private CacheConstant() {}
+}

--- a/backend/src/main/java/com/hyx/shortdrama/constant/CommonConstant.java
+++ b/backend/src/main/java/com/hyx/shortdrama/constant/CommonConstant.java
@@ -14,5 +14,15 @@ public interface CommonConstant {
      * 降序
      */
     String SORT_ORDER_DESC = " descend";
+
+    /**
+     * 列表/搜索页上限
+     */
+    public static final int PAGE_SIZE_LIMIT = 20;
+
+    /**
+     * feed 上限
+     */
+    public static final int FEED_SIZE_LIMIT = 20;
     
 }

--- a/backend/src/main/java/com/hyx/shortdrama/service/DramaService.java
+++ b/backend/src/main/java/com/hyx/shortdrama/service/DramaService.java
@@ -39,4 +39,10 @@ public interface DramaService extends IService<Drama> {
      * 分页获取vo
      */
     Page<DramaVO> getDramaVOPage(Page<Drama> dramaPage, HttpServletRequest request);
+
+    Page<DramaVO> listPublic(long current, long pageSize, String category, HttpServletRequest request);
+
+    DramaVO getDramaDetail(long id, HttpServletRequest request);
+
+    Page<DramaVO> search(String searchText, long current, long pageSize, String category, HttpServletRequest request);
 }

--- a/backend/src/main/java/com/hyx/shortdrama/service/VideoService.java
+++ b/backend/src/main/java/com/hyx/shortdrama/service/VideoService.java
@@ -8,6 +8,7 @@ import com.hyx.shortdrama.model.entity.Video;
 import com.hyx.shortdrama.model.vo.VideoVO;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.List;
 
 public interface VideoService extends IService<Video> {
 
@@ -18,4 +19,8 @@ public interface VideoService extends IService<Video> {
     VideoVO getVideoVO(Video video, HttpServletRequest request);
 
     Page<VideoVO> getVideoVOPage(Page<Video> page, HttpServletRequest request);
+
+    List<VideoVO> listEpisodes(long dramaId, HttpServletRequest request);
+
+    Page<VideoVO> feed(long current, long pageSize, Long dramaId, HttpServletRequest request);
 }

--- a/backend/src/main/java/com/hyx/shortdrama/utils/CacheKeyBuilders.java
+++ b/backend/src/main/java/com/hyx/shortdrama/utils/CacheKeyBuilders.java
@@ -1,0 +1,17 @@
+package com.hyx.shortdrama.utils;
+
+public final class CacheKeyBuilders {
+    public static String dramaList(String category, long current, long pageSize) {
+        return "c=" + (category == null ? "" : category) + ":p=" + current + ":s=" + pageSize;
+    }
+    public static String dramaDetail(long id) { return String.valueOf(id); }
+    public static String videoEpisodes(long dramaId) { return String.valueOf(dramaId); }
+    public static String videoFeed(Long dramaId, long current, long pageSize) {
+        return "d=" + (dramaId == null ? "" : dramaId) + ":p=" + current + ":s=" + pageSize;
+    }
+    public static String dramaSearch(String q, String category, long current, long pageSize) {
+        return "q=" + (q == null ? "" : q) + ":c=" + (category == null ? "" : category)
+                + ":p=" + current + ":s=" + pageSize;
+    }
+    private CacheKeyBuilders() {}
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -24,11 +24,11 @@ spring:
     password: "00000000"
   # Redis 配置
   # todo 需替换配置，然后取消注释
-#  redis:
-#    database: 1
-#    host: localhost
-#    port: 6379
-#    timeout: 5000
+  redis:
+    database: 1
+    host: localhost
+    port: 6379
+    timeout: 5000
 #    password: 123456
   # Elasticsearch 配置
   # todo 需替换配置，然后取消注释
@@ -99,3 +99,13 @@ knife4j:
         api-rule: package
         api-rule-resources:
           - com.hyx.shortdrama.controller
+
+shortdrama:
+  cache:
+    enabled: true
+    ttl:
+      dramaList: 5m
+      dramaDetail: 30m
+      videoEpisodes: 30m
+      videoFeed: 30s
+      dramaSearch: 30s


### PR DESCRIPTION
- Configure Redis cache manager with configurable TTL
- Cache drama list/details, video episodes/feed, and search results
- Implement cache invalidation on data mutations
- Extract constants and make cache settings configurable
- Add sync=true to prevent cache stampede